### PR TITLE
Add build dependencies to fedora

### DIFF
--- a/docs/compiling-coreboot.md
+++ b/docs/compiling-coreboot.md
@@ -14,7 +14,7 @@ Building and flashing your own firmware has the potential to brick your device. 
 1. **Install tools and libraries needed for coreboot:**
   * Debian based distros: `sudo apt-get install -y bison build-essential curl flex git gnat libncurses5-dev m4 zlib1g-dev`
   * Arch based distros: `sudo pacman -S base-devel curl git gcc-ada ncurses zlib`
-  * Redhat based distros: `sudo dnf install git make gcc-gnat flex bison xz bzip2 gcc g++ ncurses-devel wget zlib-devel patch`
+  * Redhat based distros: `sudo dnf install git make gcc-gnat flex bison xz bzip2 gcc g++ ncurses-devel wget zlib-devel patch openssl libuuid-devel nasm`
 2. **Clone the repository:**
     * `git clone https://github.com/mrchromebox/coreboot`
 3. **`cd` to the coreboot folder, then build the coreboot toolchain**


### PR DESCRIPTION
Fedora had me install the `openssl`, `libuuid-devel`, and `nasm` packages to build coreboot