### PR TITLE
change wording in "Can I get AVS or SOF drivers for free?"

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -18,7 +18,7 @@ Please read this page before asking a question in the Discord. Your help request
 * See [here](https://chrultrabook.github.io/docs/docs/csdriver.html)
 
 **Can I get AVS or SOF drivers for free?**
-* No.
+* Only the Linux drivers are free.
  
 **How come audio isn't working on Ubuntu / Ubuntu forks?**
 * Because their packages are broken. Please switch to another distro that isn't based off of Ubuntu, like Arch Linux or Fedora.


### PR DESCRIPTION
This pr was made to change the ["Can I get AVS or SOF drivers for free?"](https://chrultrabook.github.io/docs/docs/faq.html) faq section to avoid implying that all AVS or SOF drivers are not free but bring up that only the Linux drivers are free.