### PR TITLE
Fix system-info.md note

### DIFF
--- a/docs/system-info.md
+++ b/docs/system-info.md
@@ -4,7 +4,8 @@ layout: default
 nav_order: 5
 ---
 
-{: .note } Some of the following commands require [Developer mode](firmware.md).
+{: .note } 
+Some of the following commands require [Developer mode](firmware.md).
 
 ### System Architecture
 


### PR DESCRIPTION
This pr fixes the formatting of the new [system-info](https://github.com/chrultrabook/docs/blob/b110dcbd0e429eaa60aa335903a8f444cf33ef13/docs/system-info.md?plain=1#L7) note so that it displays correctly