### PR TITLE
Add Linux workaround instructions for CELES

### DIFF
--- a/docs/post-install.md
+++ b/docs/post-install.md
@@ -51,6 +51,14 @@ nav_order: 16
    ```
 3. Enable the systemd service by typing `systemctl enable  --now chromebook-usbc.service`, then it should work.
 
+**CELES Post Install Workaround**
+
+If you experience issues in applications such as Parsec, or encounter disruptive freezes, adding the kernel parameters `clocksource=hpet hpet=force` may fix your problem. The following instructions assume you're using GRUB, and will be different for other bootloaders. Do your own research on how to set kernel parameters in your bootloader if these do not apply.
+1. Edit `/etc/default/grub` with your preferred text editor (e.g. nano).
+2. Add `clocksource=hpet hpet=force` inside of GRUB_CMDLINE_LINUX_DEFAULT and save your changes. If you exclude either parameter, this will not work. Use sudo, su, or doas if necessary.
+3. Type `grub-mkconfig -o /boot/grub/grub.cfg` or `update-grub` into a terminal and press Enter. Use sudo, su, or doas if necessary.
+4. Reboot
+
 -----------------------
 
 


### PR DESCRIPTION
This seems to be the equivalent of "useplatformclock true" as it forces use of the HPET timer. For one user, switching to HPET has shown to be effective in fixing crashes in applications such as Parsec. Additionally, it may have fixed another user's stuttering issues.

Here are some sources from the chultrabook Discord server that have shown success following these steps:
[https://discord.com/channels/232609321274310656/232609321274310656/1141805003258986597](url)
[https://discord.com/channels/232609321274310656/1033119537656234097/1150696423734640730](url)

Going by these, I'm confident that these parameters do have a positive effect on this device, and that we should add them to the docs for others to experiment with them.