### PR TITLE
add cros-keyboard-map script

### DIFF
--- a/docs/post-install.md
+++ b/docs/post-install.md
@@ -29,9 +29,8 @@ nav_order: 16
 **General QOL Fixes**
 
 * Run the [audio script](https://github.com/WeirdTreeThing/chromebook-linux-audio) if you haven't already.
-* Install [keyd](https://github.com/rvaiya/keyd) with the instructions in the README to remap top row FX keys.
-  * Pick the relevant [keyboard layout](https://github.com/chrultrabook/keydconfig) and copy to `/etc/keyd/default.conf`
-
+* Run the [cros-keyboard-map](https://github.com/WeirdTreeThing/cros-keyboard-map) script to remap top row FX keys.
+ 
 **Fixing USB C on TigerLake and AlderLake**
 1. Create a file called `chromebook-usbc.service` file in `/etc/systemd/system/`
 2. Paste the following contents into the file:


### PR DESCRIPTION
Since the [keydconfig](https://github.com/chrultrabook/keydconfig) repo is archived and links to the newer version, point to the newer version instead of the old one.