### PR TITLE
Change Ubuntu warning + add custom kernel warning for debian

### DIFF
--- a/docs/bootableusb.md
+++ b/docs/bootableusb.md
@@ -16,7 +16,7 @@ Flashing Ventoy or ISO's to an external drive will **wipe all data** on said dri
 
 ### Downloading a ISO
 1. Determine what OS you want.
-   - For Linux, keep in mind Ubuntu and any derivatives will not work.
+   - For Linux, keep in mind Ubuntu and any derivatives not based on 23.10 or higher **may have issues**.
    - For Windows, keep in mind only Windows 10 and newer are supported.
 2. Place the ISO in a safe place.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,6 +19,9 @@ Please read this page before asking a question in the Discord. Your help request
 
 **Can I get AVS or SOF drivers for free?**
 * Only the Linux drivers are free.
+  
+**How come audio isn't working on Ubuntu / Ubuntu forks?**
+* Ubuntu distros that are not based on 23.10 or higher may have some issues, try swtiching to a non lts version.
 
 **What Linux distros are recommended?**
 * See [here](https://chrultrabook.github.io/docs/docs/installing-linux.html)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,9 +19,6 @@ Please read this page before asking a question in the Discord. Your help request
 
 **Can I get AVS or SOF drivers for free?**
 * Only the Linux drivers are free.
- 
-**How come audio isn't working on Ubuntu / Ubuntu forks?**
-* Because their packages are broken. Please switch to another distro that isn't based off of Ubuntu, like Arch Linux or Fedora.
 
 **What Linux distros are recommended?**
 * See [here](https://chrultrabook.github.io/docs/docs/installing-linux.html)

--- a/docs/installing-linux.md
+++ b/docs/installing-linux.md
@@ -18,6 +18,9 @@ Only Linux kernel 6.4 or newer is supported.
 Ubuntu and Ubuntu-based distributions that are not based on 23.10 or higher **may have issues**.
 
 {: .warning } 
+Debian versions older than Debian 12 (Bookworm) are **not supported**.
+
+{: .warning } 
 Debian 12 (Bookworm) requires a custom kernel, the [audio script](https://chrultrabook.github.io/docs/docs/installing-linux.html#fixing-audio) will automatically install it for you.
 
 **Recommended distros as of August 2023 (in no particular order) are:**

--- a/docs/installing-linux.md
+++ b/docs/installing-linux.md
@@ -18,7 +18,7 @@ Only Linux kernel 6.4 or newer is supported.
 Ubuntu and Ubuntu-based distributions that are not based on 23.10 or higher **may have issues**.
 
 {: .warning } 
-Debian 12 (Bookworm) requires a custom kernel (todo: add segment to install it).
+Debian 12 (Bookworm) requires a custom kernel, the [audio script](https://chrultrabook.github.io/docs/docs/installing-linux.html#fixing-audio) will automatically install it for you.
 
 **Recommended distros as of August 2023 (in no particular order) are:**
 

--- a/docs/installing-linux.md
+++ b/docs/installing-linux.md
@@ -12,10 +12,13 @@ Thanks to recent advancements in the chrultrabook community, Linux works really 
 ### Recommended Distributions
 
 {: .note } 
-Only Linux kernel 6.1 LTS or newer is supported.
+Only Linux kernel 6.4 or newer is supported.
 
 {: .warning } 
-Ubuntu and Ubuntu-based distributions, such as Mint or ElementaryOS are unsupported.
+Ubuntu and Ubuntu-based distributions that are not based on 23.10 or higher **may have issues**.
+
+{: .warning } 
+Debian 12 (Bookworm) requires a custom kernel (todo: add segment to install it).
 
 **Recommended distros as of August 2023 (in no particular order) are:**
 


### PR DESCRIPTION
This PR updates the docs about the situation of Ubuntu and adds a custom kernel warning for Debian in [installing-linux.md](https://github.com/chrultrabook/docs/blob/main/docs/installing-linux.md)