### PR TITLE
Further update to support notes for AMD Ryzen

### DIFF
--- a/supported-devices/devices.json
+++ b/supported-devices/devices.json
@@ -1613,7 +1613,7 @@
         "default_wpmethod": "<a href=\"https://wiki.mrchromebox.tech/Firmware_Write_Protect#Hardware_Write_Protection\" title=\"Firmware Write Protect\">CR50</a>",
         "default_rwLegacy": true,
         "default_fullrom": true,
-        "default_windows": "WIP Windows support.",
+        "default_windows": "Audio and USB4 drivers are paid.",
         "default_mac": "No MacOS support.",
         "default_linux": "Audio may not work.",
         "devices": [
@@ -1748,7 +1748,7 @@
         "default_wpmethod": "<a href=\"https://wiki.mrchromebox.tech/Firmware_Write_Protect#Hardware_Write_Protection\" title=\"Firmware Write Protect\">CR50 (battery)</a>",
         "default_rwLegacy": true,
         "default_fullrom": true,
-        "default_windows": "Supported",
+        "default_windows": "Supported, but eMMC models can boot only from external drive",
         "default_mac": "No MacOS support.",
         "default_linux": "Needs to add \"iommu=pt\" to cmdline<br><br>eMMC models need to put /boot/efi and /boot on USB",
         "devices": [
@@ -1812,7 +1812,7 @@
         "default_wpmethod": "<a href=\"https://wiki.mrchromebox.tech/Firmware_Write_Protect#Hardware_Write_Protection\" title=\"Firmware Write Protect\">CR50</a>, jumper",
         "default_rwLegacy": true,
         "default_fullrom": true,
-        "default_windows": "Not supported.",
+        "default_windows": "Waiting on drivers to be signed.",
         "default_mac": "No MacOS support.",
         "default_linux": "Speakers are not working currently.",
         "devices": [

--- a/supported-devices/template.md
+++ b/supported-devices/template.md
@@ -24,7 +24,7 @@ A device having firmware available (either RW_LEGACY or UEFI Full ROM) does not 
 
 | Intel | AMD | ARM |
 | - | - | - |
-| Intel platforms have good support for both Linux and Windows. Some have support for macOS | Ryzen needs RWL hack in order to install Windows. Stoney support in Windows is questionable, and has a few issues when running Linux. MacOS is unsupported.  | Currently unsupported by Windows. [PostmarketOS](https://wiki.postmarketos.org/wiki/Chrome_OS_devices) has support for a few ARM Chromebooks. |
+| Intel platforms have good support for both Linux and Windows. Some have support for macOS. | Stoneyridge support in Windows is questionable, and has a few issues when running Linux. MacOS is unsupported. | Currently unsupported by Windows. [PostmarketOS](https://wiki.postmarketos.org/wiki/Chrome_OS_devices) has support for a few ARM Chromebooks. |
 
 ---------
 

--- a/supported-devices/template.md
+++ b/supported-devices/template.md
@@ -24,7 +24,7 @@ A device having firmware available (either RW_LEGACY or UEFI Full ROM) does not 
 
 | Intel | AMD | ARM |
 | - | - | - |
-| Intel platforms have good support for both Linux and Windows. Some have support for macOS. | Stoneyridge support in Windows is questionable, and has a few issues when running Linux. MacOS is unsupported. | Currently unsupported by Windows. [PostmarketOS](https://wiki.postmarketos.org/wiki/Chrome_OS_devices) has support for a few ARM Chromebooks. |
+| Intel platforms have good support for both Linux and Windows. Some have support for macOS. | Stoneyridge support in Windows is questionable, and installing a custom kernel is required to get working audio in Linux. Ryzen has support for both Linux and Windows. MacOS is unsupported on all AMD platforms. | Currently unsupported by Windows. [PostmarketOS](https://wiki.postmarketos.org/wiki/Chrome_OS_devices) has support for a few ARM Chromebooks. |
 
 ---------
 


### PR DESCRIPTION
Supplements commit a38ed64 by WeirdTreeThing with latest info referenced from https://coolstar.org/chromebook/windows.html

Reiterate booting from eMMC is not supported on AMD Picasso devices in the Windows Notes column (please advise if this can be worded better, much appreciated thanks!)

Remove outdated info about Ryzen needing RWL hack