### PR TITLE
Remove accidental bold trace in unbricking/index.md

### DIFF
--- a/src/docs/unbricking/index.md
+++ b/src/docs/unbricking/index.md
@@ -233,7 +233,7 @@ You don't need to do this if flashing a stock firmware backup created by the Fir
 
 Now the firmware image is ready to be flashed, and will maintain the device's unique serial, LAN MAC address, etc.
 
-### Flashing Your Device**
+### Flashing Your Device
 
 Now that everything is prepped, time to flash the device.
 


### PR DESCRIPTION
It was there since the page originally used bolded text for headers, and was probably left there as an artifact due to an accident.