### PR TITLE
unbricking/index.md remove padding from tip

### DIFF
--- a/src/docs/unbricking/index.md
+++ b/src/docs/unbricking/index.md
@@ -5,8 +5,7 @@ prev: false
 # Unbricking
 
 ::: tip
-    Try preforming a EC reset beforehand to see if your device can recover.
-
+Try preforming a EC reset beforehand to see if your device can recover.
 :::
 ---
 If your device's firmware got into a bad state (wont POST), you can try unbricking it.


### PR DESCRIPTION
This fixes an issue where the [text](https://github.com/chrultrabook/docs/blob/b3052bbfb49b3aa42cd229b493292fa1549c61f6/src/docs/unbricking/index.md?plain=1#L8) of said tip would stay white in light mode.