### PR TITLE
Clarified how to boot from RW_LEGACY

### DIFF
--- a/src/docs/firmware/flashing-firmware.md
+++ b/src/docs/firmware/flashing-firmware.md
@@ -38,6 +38,6 @@ It can take up to a minute for display to come up on first POST. **Do not interr
 
 On the developer mode boot screen, press `CTRL` + `L`. If a selection appears, pick "Tianocore".
 
-If you are met with a white `Alternative Firmware Menu` screen (after pressing `CTRL` + `L`), enter `2` to boot from USB or `0` to boot from the internal storage (where you installed your Linux OS).
+If you are met with a white `Alternative Firmware Menu` screen (after pressing `CTRL` + `L`), enter `2` to boot from USB or `0` to boot from internal storage (where you installed your Linux OS).
 
-Further boot options can be accessed after you have entered a number, by pressing `ESC` as signified by the booting screen.
+Further boot options can be accessed after you have entered a number, by pressing `ESC` as signified by the booting screen. If you wish to access these options before you've installed an OS, press `0` then `ESC`.

--- a/src/docs/firmware/flashing-firmware.md
+++ b/src/docs/firmware/flashing-firmware.md
@@ -37,3 +37,7 @@ It can take up to a minute for display to come up on first POST. **Do not interr
 **RW_Legacy**
 
 On the developer mode boot screen, press `CTRL` + `L`. If a selection appears, pick "Tianocore".
+
+If you are met with a white `Alternative Firmware Menu` screen (after pressing `CTRL` + `L`), enter `2` to boot from USB or `0` to boot from the internal storage (where you installed your Linux OS).
+
+Further boot options can be accessed after you have entered a number, by pressing `ESC` as signified by the booting screen.

--- a/src/docs/installing/installing-linux.md
+++ b/src/docs/installing/installing-linux.md
@@ -35,6 +35,10 @@ Debian versions older than Debian 12 (Bookworm) are **not supported**. Debian 12
 3. Turn on the Chromebook, press `ESC` at the POST screen (when the coreboot logo appears), and select your USB to boot from. 
 4. Install as you would on any other computer.
 
+::: tip
+If you are using `RW_LEGACY` firmware, and after pressing `CTRL` + `L` you reach the `Additional Firmware Menu` white screen, you will need to press `2` to boot from a USB.
+:::
+
 ---
 
 ## Fixing Audio

--- a/src/docs/installing/installing-linux.md
+++ b/src/docs/installing/installing-linux.md
@@ -36,7 +36,7 @@ Debian versions older than Debian 12 (Bookworm) are **not supported**. Debian 12
 4. Install as you would on any other computer.
 
 ::: tip
-If you are using `RW_LEGACY` firmware, and after pressing `CTRL` + `L` you reach the `Additional Firmware Menu` white screen, you will need to press `2` to boot from a USB.
+If you are using `RW_LEGACY` firmware, if after pressing `CTRL` + `L` you reach the `Additional Firmware Menu` white screen, you will need to press `2` to boot from a USB.
 
 See [this page](../firmware/flashing-firmware.md) for more information about RW_LEGACY booting.
 :::

--- a/src/docs/installing/installing-linux.md
+++ b/src/docs/installing/installing-linux.md
@@ -37,6 +37,8 @@ Debian versions older than Debian 12 (Bookworm) are **not supported**. Debian 12
 
 ::: tip
 If you are using `RW_LEGACY` firmware, and after pressing `CTRL` + `L` you reach the `Additional Firmware Menu` white screen, you will need to press `2` to boot from a USB.
+
+See [this page] (firmware/flashing-firmware.md) for more information about RW_LEGACY booting.
 :::
 
 ---

--- a/src/docs/installing/installing-linux.md
+++ b/src/docs/installing/installing-linux.md
@@ -38,7 +38,7 @@ Debian versions older than Debian 12 (Bookworm) are **not supported**. Debian 12
 ::: tip
 If you are using `RW_LEGACY` firmware, and after pressing `CTRL` + `L` you reach the `Additional Firmware Menu` white screen, you will need to press `2` to boot from a USB.
 
-See [this page](firmware/flashing-firmware.md) for more information about RW_LEGACY booting.
+See [this page](../firmware/flashing-firmware.md) for more information about RW_LEGACY booting.
 :::
 
 ---

--- a/src/docs/installing/installing-linux.md
+++ b/src/docs/installing/installing-linux.md
@@ -38,7 +38,7 @@ Debian versions older than Debian 12 (Bookworm) are **not supported**. Debian 12
 ::: tip
 If you are using `RW_LEGACY` firmware, and after pressing `CTRL` + `L` you reach the `Additional Firmware Menu` white screen, you will need to press `2` to boot from a USB.
 
-See [this page] (firmware/flashing-firmware.md) for more information about RW_LEGACY booting.
+See [this page](firmware/flashing-firmware.md) for more information about RW_LEGACY booting.
 :::
 
 ---


### PR DESCRIPTION
When following the guide using `RW_LEGACY` firmware on my Chromebook, I was met with a white "Additional Firmware Menu" blank screen after pressing `CTRL` + `L`. It was unclear where to go from here if this occurs. You simply need to press 0 for internal storage boot or 2 for USB boot. This left me confused as it is not mentioned in the docs.

I have added a TIP on installing linux on how to boot this way, along with further information under "Flashing firmware" -> "RW_LEGACY" at the bottom of the page.