### PR TITLE
Updated info for SARIEN

### DIFF
--- a/supported-devices/devices.json
+++ b/supported-devices/devices.json
@@ -1031,7 +1031,7 @@
                     "Dell Latitude 5400 Chromebook Enterprise"
                 ],
                 "boardname": "SARIEN",
-                "linux": "This model has an uncommon keyboard configuration. To enable the brightness, audio, and keyboard-backlight-brightness function keys, use <a href=\"https://github.com/eupnea-project/eupnea-utils/blob/main/configs/keyboard-layouts/cros-sarien.conf\">this</a> configuration file with <a href=\"https://github.com/rvaiya/keyd\">keyd</a>. Sim card slot was not tested."
+                "linux": "Sim card slot was not tested. Everything else works under RW_LEGACY. This Chromebook has upgradable RAM and SSD."
             }
         ]
     },

--- a/supported-devices/devices.json
+++ b/supported-devices/devices.json
@@ -1031,6 +1031,7 @@
                     "Dell Latitude 5400 Chromebook Enterprise"
                 ],
                 "boardname": "SARIEN"
+                "linux": "Sim card slot not tested. Everything else (including webcam, mic, speakers, keyboard backlight, brightness control) works with the RW_Legacy firmware."
             }
         ]
     },

--- a/supported-devices/devices.json
+++ b/supported-devices/devices.json
@@ -1031,7 +1031,7 @@
                     "Dell Latitude 5400 Chromebook Enterprise"
                 ],
                 "boardname": "SARIEN",
-                "linux": "Sim card slot was not tested. Everything else (including webcam, mic, speakers, keyboard backlight, brightness control) works with the RW_Legacy firmware. This model has an uncommon keyboard configuration. Use [this](https://github.com/eupnea-project/eupnea-utils/blob/main/configs/keyboard-layouts/cros-sarien.conf) configuration file with [`keyd`](https://github.com/rvaiya/keyd) to enable the brightness, audio, and keyboard-backlight-brightness function keys."
+                "linux": "Webcam, mic, speakers, keyboard backlight, brightness control works with the RW_Legacy firmware. This model has an uncommon keyboard configuration. To enable enable the brightness, audio, and keyboard-backlight-brightness function keys, use <a href=\"https://wiki.mrchromebox.tech/Firmware_Write_Protect#Hardware_Write_Protection\">this</a> configuration file with <a href=\"https://github.com/rvaiya/keyd\">keyd</a>. Sim card slot was not tested."
             }
         ]
     },

--- a/supported-devices/devices.json
+++ b/supported-devices/devices.json
@@ -1030,8 +1030,8 @@
                 "device": [
                     "Dell Latitude 5400 Chromebook Enterprise"
                 ],
-                "boardname": "SARIEN"
-                "linux": "Sim card slot not tested. Everything else (including webcam, mic, speakers, keyboard backlight, brightness control) works with the RW_Legacy firmware."
+                "boardname": "SARIEN",
+                "linux": "Sim card slot was not tested. Everything else (including webcam, mic, speakers, keyboard backlight, brightness control) works with the RW_Legacy firmware. This model has an uncommon keyboard configuration. Use [this](https://github.com/eupnea-project/eupnea-utils/blob/main/configs/keyboard-layouts/cros-sarien.conf) configuration file with [`keyd`](https://github.com/rvaiya/keyd) to enable the brightness, audio, and keyboard-backlight-brightness function keys."
             }
         ]
     },

--- a/supported-devices/devices.json
+++ b/supported-devices/devices.json
@@ -1031,7 +1031,7 @@
                     "Dell Latitude 5400 Chromebook Enterprise"
                 ],
                 "boardname": "SARIEN",
-                "linux": "Webcam, mic, speakers, keyboard backlight, brightness control works with the RW_Legacy firmware. This model has an uncommon keyboard configuration. To enable enable the brightness, audio, and keyboard-backlight-brightness function keys, use <a href=\"https://wiki.mrchromebox.tech/Firmware_Write_Protect#Hardware_Write_Protection\">this</a> configuration file with <a href=\"https://github.com/rvaiya/keyd\">keyd</a>. Sim card slot was not tested."
+                "linux": "This model has an uncommon keyboard configuration. To enable the brightness, audio, and keyboard-backlight-brightness function keys, use <a href=\"https://github.com/eupnea-project/eupnea-utils/blob/main/configs/keyboard-layouts/cros-sarien.conf\">this</a> configuration file with <a href=\"https://github.com/rvaiya/keyd\">keyd</a>. Sim card slot was not tested."
             }
         ]
     },


### PR DESCRIPTION
Updated info for SARIEN Chromebook.

Full UEFI is not supported in this Chromebook, but everything I tested works under RW_Legacy firmware with Linux Mint 22.3.

This Chromebook has upgradable RAM and SSD, but I am not sure whether that too should be added to the notes.