### PR TITLE
Add additional things to the Ti50 AP FW RO verification PR

### DIFF
--- a/src/docs/firmware/ti50-ap-ro.md
+++ b/src/docs/firmware/ti50-ap-ro.md
@@ -27,9 +27,25 @@ If your device has a Ti50 and you don't disable RO verification, flashing full r
 :::
 
 ## Recovering a device bricked due to RO verification.
-1. Press and hold the power button.
-2. Press the refresh button twice.
-3. Release the power button.
+### Chromebooks
+
+1. Press and hold the `Power` button.
+2. Press the `Refresh` (arrow icon) button twice.
+3. Release the `Power` button.
+4. Repeat the above steps a second time.
+
+### Chromeboxes
+
+1. Press and hold the `Power` button.
+2. Press the recovery pinhole button twice.
+3. Release the `Power` button.
+4. Repeat the above steps a second time.
+
+### Tablets
+
+1. Press and hold the `Power` button.
+2. Press and hold `Volume Up` for 10+ seconds. Release and repeat it a second time.
+3. Release the `Power` button.
 4. Repeat the above steps a second time.
 
 This will disable RO verification for 15 minutes, allowing you to permanently disable it.

--- a/src/docs/firmware/write-protect.md
+++ b/src/docs/firmware/write-protect.md
@@ -15,4 +15,7 @@ Depending on your device, you will need to do **one** of the following:
 - [Unplug your battery](battery.md)
 - Bridge two jumpers
 - [Use a SuzyQable](suzyq.md) (A cable that enables CCD (Closed Case Debug))
-- On devices with a Ti50 security chip (2023+), you will additionally need to [disable RO verification](ti50-ap-ro.md)
+
+::: warning
+On devices with a Ti50 security chip (2023+), you will additionally need to [disable RO verification](ti50-ap-ro.md).
+:::

--- a/src/docs/unbricking/index.md
+++ b/src/docs/unbricking/index.md
@@ -7,6 +7,10 @@ prev: false
 ::: tip
 Try preforming a EC reset beforehand to see if your device can recover.
 :::
+
+::: tip
+If your device has a Ti50 chip and you didn't disable RO verification before flashing, follow [this guide](../firmware/ti50-ap-ro.md#recovering-a-device-bricked-due-to-ro-verification) to recover it.
+:::
 ---
 If your device's firmware got into a bad state (wont POST), you can try unbricking it.
 Here is the following ways that you can unbrick your device:


### PR DESCRIPTION
This PR includes the following things for PR #159.

- Changing the Ti50 inclusion in write-protect.md to a warning since this feels like something the reader should watch out for.
- Adding Chromebox and Tablet recovery sections in ti50-ap-ro.md.
- Referencing it in unbricking/index.md