### PR TITLE
Adding documentation to fix USI Stylus rotation.

### DIFF
--- a/src/docs/installing/post-install.md
+++ b/src/docs/installing/post-install.md
@@ -65,7 +65,9 @@ If you experience issues in applications such as Parsec, or encounter disruptive
 
 Some Chromebooks come with USI styluses. They work fine in the newest versions of KDE Plasma, but they have a rotation issue in GNOME. The issue is that the stylus does not rotate with the screen, so it is only usable in one orientation. To fix this, we have to add an libinput override.
 
-1. Get the device ID of your stylus by running this script https://github.com/linuxwacom/libwacom/blob/master/tools/show-stylus.py.
+1. Get the device ID of your stylus
+   This information can either be read from cbmem or libwacom.
+   To get the ID from libwacom run this script https://github.com/linuxwacom/libwacom/blob/master/tools/show-stylus.py.
    ``` bash
    tux@fedora:~/Downloads/libwacom/tools$ sudo python ./show-stylus.py 
    Using "GDIX0000:00 27C6:0E0C Stylus": /dev/input/event5
@@ -77,7 +79,7 @@ Some Chromebooks come with USI styluses. They work fine in the newest versions o
    ```
    In this case, the device ID is `GDIX0000:00 27C6:0E0C Stylus`.
 
-2. Create a .tablet file for libwacom
+3. Create a .tablet file for libwacom
    ``` bash
    sudo mkdir -p /etc/libwacom/
    sudo nano /etc/libwacom/google-{your board name}.tablet
@@ -99,7 +101,7 @@ Some Chromebooks come with USI styluses. They work fine in the newest versions o
    Stylus=true
    Touch=false
    ```
-3. Create the libinput override
+4. Create the libinput override
    ``` bash
    sudo mkdir -p /etc/libinput/
    sudo nano /etc/libinput/local-overrides.quirks
@@ -113,7 +115,7 @@ Some Chromebooks come with USI styluses. They work fine in the newest versions o
    ModelChromebook=1
    AttrPressureRange=1100:1000
    ```
-4. Update the libwacom database and restart the system
+5. Update the libwacom database and restart the system
    ``` bash
    sudo libwacom-update-db
    reboot

--- a/src/docs/installing/post-install.md
+++ b/src/docs/installing/post-install.md
@@ -79,7 +79,7 @@ Some Chromebooks come with USI styluses. They work fine in the newest versions o
    ```
    In this case, the device ID is `GDIX0000:00 27C6:0E0C Stylus`.
 
-3. Create a .tablet file for libwacom
+2. Create a .tablet file for libwacom
    ``` bash
    sudo mkdir -p /etc/libwacom/
    sudo nano /etc/libwacom/google-{your board name}.tablet
@@ -101,7 +101,7 @@ Some Chromebooks come with USI styluses. They work fine in the newest versions o
    Stylus=true
    Touch=false
    ```
-4. Create the libinput override
+3. Create the libinput override
    ``` bash
    sudo mkdir -p /etc/libinput/
    sudo nano /etc/libinput/local-overrides.quirks
@@ -115,7 +115,7 @@ Some Chromebooks come with USI styluses. They work fine in the newest versions o
    ModelChromebook=1
    AttrPressureRange=1100:1000
    ```
-5. Update the libwacom database and restart the system
+4. Update the libwacom database and restart the system
    ``` bash
    sudo libwacom-update-db
    reboot

--- a/src/docs/installing/post-install.md
+++ b/src/docs/installing/post-install.md
@@ -61,7 +61,7 @@ If you experience issues in applications such as Parsec, or encounter disruptive
 3. Type `grub-mkconfig -o /boot/grub/grub.cfg` or `update-grub` into a terminal and press Enter. Use sudo, su, or doas if necessary.
 4. Reboot
 
-### Fixing Stylus on Rotation Issue
+### Fixing stylus orientation in Gnome
 
 Some Chromebooks come with USI styluses. They work fine in the newest versions of KDE Plasma, but they have a rotation issue in GNOME. The issue is that the stylus does not rotate with the screen, so it is only usable in one orientation. To fix this, we have to add an libinput override.
 

--- a/src/docs/installing/post-install.md
+++ b/src/docs/installing/post-install.md
@@ -150,7 +150,7 @@ ModelChromebook=1
 AttrPressureRange=1100:1000
 ```
 #### Consider Upstreaming Your Changes to libwacom
-Please consider upstreaming your changes to [libwacom](https://github.com/linuxwacom/wacom-hid-descriptors) and [wacom-hid-descriptors](https://github.com/linuxwacom/wacom-hid-descriptors). This will help other users with the same device as you. 
+Please consider upstreaming your changes to [libwacom](https://github.com/linuxwacom/libwacom) and [wacom-hid-descriptors](https://github.com/linuxwacom/wacom-hid-descriptors). This will help other users with the same device as you. 
 
 
 ## macOS 


### PR DESCRIPTION
Some Chromebooks come with USI styluses. They work fine in the newest versions of KDE Plasma, but they have a rotation issue in GNOME. The issue is that the stylus does not rotate with the screen, so it is only usable in one orientation.
This is a solution to this issue.

Now, this method solves the issue, but it is a bit complicated and not very beginner-friendly.
We can upstream changes to libwacom which should solve the issue for one device, but this has to be done for every device manually.
I don't know if there is a better way to solve this because this issue does not exist in KDE.
