### PR TITLE
Solve markdown linter errors specific to #159

### DIFF
--- a/src/docs/unbricking/index.md
+++ b/src/docs/unbricking/index.md
@@ -2,6 +2,7 @@
 next: false
 prev: false
 ---
+
 # Unbricking
 
 If your device's firmware got into a bad state (won't POST), you can try unbricking it.
@@ -13,7 +14,9 @@ Try performing a EC reset beforehand to see if your device can recover.
 ::: tip
 If your device has a Ti50 chip and you didn't disable RO verification before flashing, follow [this guide](../firmware/ti50-ap-ro.md#recovering-a-device-bricked-due-to-ro-verification) to recover it.
 :::
+
 ---
+
 Here is the following ways that you can unbrick your device:
 
 ### [Unbricking with a ch341a USB programmer](unbrick-ch341a)


### PR DESCRIPTION
The `MD003` heading style consistency error is caused by the (accidental) placement of a horizontal rule directly below a line of text, turning that text into a heading, which wasn't the intention.