### PR TITLE
(RFC) reword LTS warnings and notes

### DIFF
--- a/src/docs/faq.md
+++ b/src/docs/faq.md
@@ -10,9 +10,9 @@ Please read this page before asking for help. Your help request will be pointed 
 
 - This depends on your use case. Only you can answer this question.
 
-### Should I use rw-legacy or full rom?
+### Should I use RW_LEGCY or full rom?
 
-- This depends on what you are looking to use your device for. If you are planning on installing Windows or macOS you need to use full rom. RW-legacy only supports linux.
+- This depends on what you are looking to use your device for. If you are planning on installing Windows or macOS you need to use full rom. RW_LEGACY only supports linux.
 
 ### My internal keyboard doesn't work, can I use an external keyboard to get into developer mode?
 

--- a/src/docs/faq.md
+++ b/src/docs/faq.md
@@ -10,7 +10,7 @@ Please read this page before asking for help. Your help request will be pointed 
 
 - This depends on your use case. Only you can answer this question.
 
-### Should I use RW_LEGCY or full rom?
+### Should I use RW_LEGACY or full rom?
 
 - This depends on what you are looking to use your device for. If you are planning on installing Windows or macOS you need to use full rom. RW_LEGACY only supports linux.
 
@@ -105,15 +105,15 @@ Please read this page before asking for help. Your help request will be pointed 
 
 ### Audio isn't working on Debian, Ubuntu or some other Distribution?
 
-- Old (>1 year) LTS releases may have issues and are not supported, try switching to another distro.
+- Old (>1 year) LTS releases may have issues and are not supported. If the [audio script](installing/installing-linux.md#fixing-audio) doesn't fix the issue, try switching to another distro.
 
 ### What Linux distros are recommended?
 
-- See [this page](installing/installing-linux.md).
+- Please see [this page](installing/installing-linux.md).
 
 ### How can I get audio working under Linux?
 
-- Please see [this GitHub repo](https://github.com/WeirdTreeThing/chromebook-linux-audio)
+- Please see [this page](installing/installing-linux.md#fixing-audio)
 
 ### How do I get my top row keys on Linux to act like how they did on chromeOS?
 

--- a/src/docs/faq.md
+++ b/src/docs/faq.md
@@ -8,11 +8,11 @@ Please read this page before asking for help. Your help request will be pointed 
 
 ### What OS should I use?
 
-- This depends on your use case. Only you can answer this question. <!-- Not ubuntu plz -->
+- This depends on your use case. Only you can answer this question.
 
 ### Should I use rw-legacy or full rom?
 
-- This depends on what you are looking to use your device for. If you are planning on installing Windows or macOS you need to use full rom. Rw-legacy only supports linux.
+- This depends on what you are looking to use your device for. If you are planning on installing Windows or macOS you need to use full rom. RW-legacy only supports linux.
 
 ### My internal keyboard doesn't work, can I use an external keyboard to get into developer mode?
 
@@ -103,17 +103,9 @@ Please read this page before asking for help. Your help request will be pointed 
 
 ## Linux Questions
 
-### How come audio isn't working on Ubuntu / Ubuntu forks?
+### Audio isn't working on Debian, Ubuntu or some other Distribution?
 
-- Ubuntu and Ubuntu-based distros may have issues and are not supported, try switching to another distro. Debian is a great alternative if you are used to Ubuntu.
-
-### Why are Ubuntu/Ubuntu based distros not supported?
-
-- They consistently break packages.
-- They have started to force snap on their users.
-- They have published an LTS distro with a non-LTS kernel.
-
-Becuse of these things, Ubuntu is unsupported. We will not help you fix issues on Ubuntu.
+- Old (>1 year) LTS releases may have issues and are not supported, try switching to another distro.
 
 ### What Linux distros are recommended?
 

--- a/src/docs/installing/installing-linux.md
+++ b/src/docs/installing/installing-linux.md
@@ -15,7 +15,7 @@ Only Linux kernel 6.4 or newer is supported.
 
 ::: warning
 Old (>1 year) LTS releases **may have issues** and are not supported.  
-Debian 12 (Bookworm) and possibly Ubuntu require a custom kernel. In case of Debian, the [audio script](#fixing-audio) will automatically install it for you.
+One possible workaround for Debian 12 (Bookworm) and Ubuntu is using a custom kernel. In case of Debian, the audio script will automatically install it for you. Note that not all issues can be solved with a custom kernel, as the rest of the software on the system is still old.
 :::
 
 **Recommended distros as of October 2023 (in no particular order) are:**

--- a/src/docs/installing/installing-linux.md
+++ b/src/docs/installing/installing-linux.md
@@ -18,7 +18,7 @@ Old (>1 year) LTS releases **may have issues** and are not supported.
 One possible workaround for Debian 12 (Bookworm) and Ubuntu is using a custom kernel. In case of Debian, the audio script will automatically install it for you. Note that not all issues can be solved with a custom kernel, as the rest of the software on the system is still old.
 :::
 
-**Recommended distros as of October 2023 (in no particular order) are:**
+**Recommended distros as of December 2024 (in no particular order) are:**
 
 - Arch Linux or EndeavourOS
 - Fedora or Ultramarine Linux

--- a/src/docs/installing/installing-linux.md
+++ b/src/docs/installing/installing-linux.md
@@ -14,11 +14,8 @@ Only Linux kernel 6.4 or newer is supported.
 ## Recommended Distributions
 
 ::: warning
-Ubuntu and Ubuntu-based distributions **may have issues** and are **not supported**.
-:::
-
-::: warning
-Debian versions older than Debian 12 (Bookworm) are **not supported**. Debian 12 (Bookworm) requires a custom kernel, the [audio script](#fixing-audio) will automatically install it for you.
+Old (>1 year) LTS releases **may have issues** and are not supported.  
+Debian 12 (Bookworm) and possibly Ubuntu require a custom kernel. In case of Debian, the [audio script](#fixing-audio) will automatically install it for you.
 :::
 
 **Recommended distros as of October 2023 (in no particular order) are:**
@@ -26,7 +23,6 @@ Debian versions older than Debian 12 (Bookworm) are **not supported**. Debian 12
 - Arch Linux or EndeavourOS
 - Fedora or Ultramarine Linux
 - openSUSE Tumbleweed
-- Debian 12 (Bookworm)
 - Pop!\_OS
 
 ## Installation

--- a/src/docs/installing/installing-linux.md
+++ b/src/docs/installing/installing-linux.md
@@ -15,7 +15,7 @@ Only Linux kernel 6.4 or newer is supported.
 
 ::: warning
 Old (>1 year) LTS releases **may have issues** and are not supported.  
-One possible workaround for Debian 12 (Bookworm) and Ubuntu is using a custom kernel. In case of Debian, the audio script will automatically install it for you. Note that not all issues can be solved with a custom kernel, as the rest of the software on the system is still old.
+One possible workaround for Debian 12 (Bookworm) and Ubuntu is using a custom kernel. In case of Debian, the [audio script](#fixing-audio) will automatically install it for you. Note that not all issues can be solved with a custom kernel, as the rest of the software on the system is still old.
 :::
 
 **Recommended distros as of December 2024 (in no particular order) are:**


### PR DESCRIPTION
- Remove Debian from recommendations since its age starts to show
- Remove exaggerations about Ubuntu
- Generalize prior Debian warnings to old LTS releases in general