### PR TITLE
fix overhaul oversights

### DIFF
--- a/src/docs/getting-started/choose-os-fw.md
+++ b/src/docs/getting-started/choose-os-fw.md
@@ -15,7 +15,7 @@ There are three different ways to boot an alternate OS on your device, each with
 
 ### The Stock Bootloader (depthcharge)
 
-Since ChromeOS is Linux with a custom userspace, the stock bootloader (depthcharge) can load any Linux kernel. This method works on any device and does not modify the firmware at all. It is the only option on ARM devices since they do not have any custom firmware. If you choose method, refer to FyraLabs' [submarine guide](https://developer.fyralabs.com/submarine).
+Since ChromeOS is Linux with a custom userspace, the stock bootloader (depthcharge) can load any Linux kernel. This method works on any device and does not modify the firmware at all. It is the only option on ARM devices since they do not have any custom firmware. If you choose this method, refer to FyraLabs' [submarine guide](https://developer.fyralabs.com/submarine).
 
 ### RW_LEGACY (AltFW)
 

--- a/src/docs/installing/index.md
+++ b/src/docs/installing/index.md
@@ -44,10 +44,6 @@ Be sure to check the [devices page](../devices.md) to see what you can run.
 - Requires some work on the end user (running audio script, configuring keyboard mapping)
 - AVS and SOF users experience instability at times
 
-  ::: warning
-  Ubuntu and Ubuntu-based distributions **may have issues** and are **not supported**.
-  :::
-
 <br>
 
 ### [Installing Linux →](installing-linux.md)


### PR DESCRIPTION
- choose-os-fw.md: add missing `this`
- index.md: Remove linux warning since this is both redundant to installing-linux.md as well as outdated as of #217 