### PR TITLE
Add immutable distro audio fix instructions

### DIFF
--- a/src/docs/installing/installing-linux.md
+++ b/src/docs/installing/installing-linux.md
@@ -53,3 +53,12 @@ Using AVS on a device with max98357a will blow your speakers. You have been warn
 4. `./setup-audio`
 
 For more information please see [WeirdTreeThing's repo](https://github.com/WeirdTreeThing/chromebook-linux-audio)
+
+#### Atomic (Immutable) Distros
+
+If you're using an `rpm-ostree` based system (EG: Fedora Silverblue, Fedora Kinoite, Project Bluefin, Bazzite etc.) you can use [PVermeer's RPM package](https://copr.fedorainfracloud.org/coprs/pvermeer/chromebook-linux-audio) of WeirdTreeThing's script. 
+
+1. Open terminal
+2. `sudo dnf copr enable pvermeer/chromebook-linux-audio`
+3. `rpm-ostree install chromebook-linux-audio`
+4. Reboot

--- a/src/docs/installing/installing-linux.md
+++ b/src/docs/installing/installing-linux.md
@@ -54,9 +54,9 @@ Using AVS on a device with max98357a will blow your speakers. You have been warn
 
 For more information please see [WeirdTreeThing's repo](https://github.com/WeirdTreeThing/chromebook-linux-audio)
 
-#### Atomic (Immutable) Distros
+#### Atomic & Image-Based Systems
 
-If you're using an `rpm-ostree` based system (EG: Fedora Silverblue, Fedora Kinoite, Project Bluefin, Bazzite etc.) you can use [PVermeer's RPM package](https://copr.fedorainfracloud.org/coprs/pvermeer/chromebook-linux-audio) of WeirdTreeThing's script. 
+If you're using an `rpm-ostree` based system (EG: Fedora Silverblue, Fedora Kinoite, Project Bluefin, etc.) you can use [PVermeer's RPM package](https://copr.fedorainfracloud.org/coprs/pvermeer/chromebook-linux-audio) of WeirdTreeThing's script. 
 
 1. Open terminal
 2. `sudo dnf copr enable pvermeer/chromebook-linux-audio`


### PR DESCRIPTION
Adds instructions on running WeirdTreeThing's `chromebook-linux-audio` script on immutable distros. 

Only a small update, but I've tried to keep to existing styles, tone of voice etc. 

Happy to make any required changes. 

The steps in this guide have been tested by myself on a Google Pixelbook Go (2019) running [Project Bluefin](https://projectbluefin.io/), and resulted in working audio from the built in speakers. 