### PR TITLE
Update Stoney Ridge audio on Linux requirements

### DIFF
--- a/devices/os-support.json
+++ b/devices/os-support.json
@@ -44,7 +44,7 @@
     "devices": [
       {
         "boardname": "CELES",
-        "windows": "Requires platform clock workaround. (See <a href=\"../installing/post-install\">post install</a>)"
+        "windows": "Requires platform clock workaround. (See <a href=\"./installing/post-install\">post install</a>)"
       },
       {
         "windows": "No microphone support",
@@ -173,7 +173,7 @@
   "Intel TigerLake": {
     "default_windows": "Audio and Thunderbolt drivers are paid.",
     "default_mac": "No MacOS support.",
-    "default_linux": "No fingerprint functionality on models that have it.<br><br>USB4 requires systemd service (See <a href=\"../installing/post-install\">post install</a>)",
+    "default_linux": "No fingerprint functionality on models that have it.<br><br>USB4 requires systemd service (See <a href=\"./installing/post-install\">post install</a>)",
     "devices": []
   },
   "Intel JasperLake": {
@@ -185,7 +185,7 @@
   "Intel Alderlake": {
     "default_windows": "Audio and Thunderbolt drivers are paid.",
     "default_mac": "No MacOS support.",
-    "default_linux": "No fingerprint functionality on models that have it.<br><br>USB4 requires systemd service (See <a href=\"../installing/post-install\">post install</a>)",
+    "default_linux": "No fingerprint functionality on models that have it.<br><br>USB4 requires systemd service (See <a href=\"./installing/post-install\">post install</a>)",
     "devices": [
       {
         "boardname": "KANO",

--- a/devices/os-support.json
+++ b/devices/os-support.json
@@ -212,7 +212,7 @@
   "AMD Stoneyridge": {
     "default_windows": "Experimental Windows support. Requires patched drivers with testsigning enabled.",
     "default_mac": "No MacOS support.",
-    "default_linux": "Needs kernel compiled with AMDGPU=Y instead of =M and firmware built-in to get working audio",
+    "default_linux": "Needs kernel in version at least 6.19 to get working audio",
     "devices": []
   },
   "AMD Picasso": {

--- a/src/docs/installing/installing-linux.md
+++ b/src/docs/installing/installing-linux.md
@@ -8,14 +8,14 @@ next: post-install
 Thanks to recent advancements in the chrultrabook community, Linux works really well on most Chromebooks.
 
 ::: tip
-Only Linux kernel 6.6 or newer is supported.
+Only Linux kernel 6.19 or newer is supported.
 :::
 
 ## Recommended Distributions
 
 ::: warning
-Old (>1 year) LTS releases **may have issues** and are not supported.  
-One possible workaround for Debian 12 (Bookworm) and Ubuntu is using a custom kernel. In case of Debian, the [audio script](#fixing-audio) will automatically install it for you. Note that not all issues can be solved with a custom kernel, as the rest of the software on the system is still old.
+Old (>1 year) LTS releases **may have issues** and are not supported.
+One possible workaround for Ubuntu is using a third-party kernel. Note that not all issues can be solved with a custom kernel, as the rest of the software on the system might be still old.
 :::
 
 **Recommended distros as of December 2024 (in no particular order) are:**

--- a/src/docs/installing/known-issues.md
+++ b/src/docs/installing/known-issues.md
@@ -13,7 +13,8 @@
 
 - Broken USB-C on TigerLake and AlderLake. See Post Install -> Linux for fix.
 - No fingerprint reader support.
-- Debian 12 (Bookworm) needs a custom kernel.
+- Debian 12 (Bookworm) needs an updated kernel from backports.
+- Stoney Ridge audio requires Linux kernel 6.19 or newer.
 
 ### macOS
 


### PR DESCRIPTION
Since kernel 6.19 we have a proper fix for ACP audio on Stoney Ridge. This PR removes mentions of unmaintained `stoney-kernel` and replaces it with kernel version requirement.

Fixes #238 